### PR TITLE
fix: Switches Reaction from performUpdate to update, fixes #26

### DIFF
--- a/src/lib/mixin.ts
+++ b/src/lib/mixin.ts
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { UpdatingElement } from 'lit-element';
+import { UpdatingElement, PropertyValues } from 'lit-element';
 import { Reaction } from 'mobx';
 
 const reaction = Symbol('LitMobxRenderReaction');
@@ -59,15 +59,13 @@ export function MobxReactionUpdate<T extends UpdatingElementConstructor>(
             }
         }
 
-        protected update(
-            _changedProperties: Map<string | number | symbol, unknown>
-        ): void {
+        protected update(changedProperties: PropertyValues): void {
             if (this[reaction]) {
                 this[reaction]!.track(
-                    super.update.bind(this, _changedProperties)
+                    super.update.bind(this, changedProperties)
                 );
             } else {
-                super.update(_changedProperties);
+                super.update(changedProperties);
             }
         }
     };

--- a/src/lib/mixin.ts
+++ b/src/lib/mixin.ts
@@ -15,7 +15,6 @@ import { Reaction } from 'mobx';
 
 const reaction = Symbol('LitMobxRenderReaction');
 const cachedRequestUpdate = Symbol('LitMobxRequestUpdate');
-const cachedPerformUpdate = Symbol('LitMobxPerformUpdate');
 
 type UpdatingElementConstructor = new (...args: any[]) => UpdatingElement;
 
@@ -36,8 +35,9 @@ export function MobxReactionUpdate<T extends UpdatingElementConstructor>(
         // NOTE: using a symbol here to avoid potential name collisions in derived classes
         private [reaction]: Reaction | undefined;
 
-        private [cachedRequestUpdate] = () => this.requestUpdate();
-        private [cachedPerformUpdate] = () => super.performUpdate();
+        private [cachedRequestUpdate] = () => {
+            this.requestUpdate();
+        };
 
         public connectedCallback(): void {
             super.connectedCallback();
@@ -59,11 +59,15 @@ export function MobxReactionUpdate<T extends UpdatingElementConstructor>(
             }
         }
 
-        protected performUpdate(): void {
+        protected update(
+            _changedProperties: Map<string | number | symbol, unknown>
+        ): void {
             if (this[reaction]) {
-                this[reaction]!.track(this[cachedPerformUpdate]!);
+                this[reaction]!.track(
+                    super.update.bind(this, _changedProperties)
+                );
             } else {
-                super.performUpdate();
+                super.update(_changedProperties);
             }
         }
     };

--- a/test/lit-mobx.test.ts
+++ b/test/lit-mobx.test.ts
@@ -10,109 +10,18 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { MobxLitElement } from '../';
-import { observable, computed } from 'mobx';
-import {
-    html,
-    customElement,
-    property,
-    TemplateResult,
-    PropertyValues,
-} from 'lit-element';
+import { html } from 'lit-element';
 import { expect, fixture, elementUpdated } from '@open-wc/testing';
-import { nothing } from 'lit-html';
+import {
+    TestMobxLitElementUpdatesArrays,
+    TestMobxLitElementUpdateChange,
+    TestMobxLitElementUpdatedChange,
+    TestMobxLitElementFirstUpdatedChange,
+} from './test-elements';
 
-@customElement('test-mobx-lit-element-updates-arrays')
-export class TestMobxLitElementUpdatesArrays extends MobxLitElement {
-    @property({ attribute: false })
-    @observable
-    public observableArray?: string[];
+// import elements for side effects
+import './test-elements';
 
-    @property()
-    public normalProperty = 'My Array';
-
-    @computed
-    private get arrayLength(): string {
-        return `Array length = ${
-            this.observableArray ? this.observableArray.length : 'N/A'
-        }`;
-    }
-
-    public render(): TemplateResult {
-        return html`
-            <p>${this.normalProperty}</p>
-            <p>
-                ${this.observableArray
-                    ? this.observableArray.join(', ')
-                    : nothing}
-            </p>
-            <p>${this.arrayLength}</p>
-        `;
-    }
-}
-
-@customElement('test-mobx-lit-element-update-change')
-export class TestMobxLitElementUpdateChange extends MobxLitElement {
-    @observable
-    public observableValue: number = 1;
-
-    @observable
-    private derivedValue: number = 1;
-
-    public update(changedProperties: PropertyValues) {
-        super.update(changedProperties);
-        this.derivedValue = this.observableValue * 2;
-    }
-
-    public render(): TemplateResult {
-        return html`
-            <p>${this.observableValue}</p>
-            <p>${this.derivedValue}</p>
-        `;
-    }
-}
-
-@customElement('test-mobx-lit-element-updated-change')
-export class TestMobxLitElementUpdatedChange extends MobxLitElement {
-    @observable
-    public observableValue: number = 1;
-
-    @observable
-    private derivedValue: number = 1;
-
-    public updated(changedProperties: PropertyValues) {
-        super.updated(changedProperties);
-        this.derivedValue = this.observableValue * 3;
-    }
-
-    public render(): TemplateResult {
-        return html`
-            <p>${this.observableValue}</p>
-            <p>${this.derivedValue}</p>
-        `;
-    }
-}
-
-@customElement('test-mobx-lit-element-first-updated-change')
-export class TestMobxLitElementFirstUpdatedChange extends MobxLitElement {
-    @observable
-    public observableValue: number = 1;
-
-    @observable
-    private derivedValue: number = 1;
-
-    public firstUpdated(changedProperties: PropertyValues) {
-        super.firstUpdated(changedProperties);
-        this.derivedValue = this.observableValue * 4;
-    }
-
-    public render(): TemplateResult {
-        return html`
-            <p>${this.observableValue}</p>
-            <p>${this.derivedValue}</p>
-        `;
-    }
-}
 describe('MobxLitElement', () => {
     it('updates arrays', async () => {
         const el = await fixture<TestMobxLitElementUpdatesArrays>(html`

--- a/test/lit-mobx.test.ts
+++ b/test/lit-mobx.test.ts
@@ -12,7 +12,13 @@ governing permissions and limitations under the License.
 
 import { MobxLitElement } from '../';
 import { observable, computed } from 'mobx';
-import { html, customElement, property, TemplateResult } from 'lit-element';
+import {
+    html,
+    customElement,
+    property,
+    TemplateResult,
+    PropertyValues,
+} from 'lit-element';
 import { expect, fixture, elementUpdated } from '@open-wc/testing';
 import { nothing } from 'lit-html';
 
@@ -53,7 +59,7 @@ export class TestMobxLitElementUpdateChange extends MobxLitElement {
     @observable
     private derivedValue: number = 1;
 
-    public update(changedProperties: Map<string | number | symbol, unknown>) {
+    public update(changedProperties: PropertyValues) {
         super.update(changedProperties);
         this.derivedValue = this.observableValue * 2;
     }
@@ -74,7 +80,7 @@ export class TestMobxLitElementUpdatedChange extends MobxLitElement {
     @observable
     private derivedValue: number = 1;
 
-    public updated(changedProperties: Map<string | number | symbol, unknown>) {
+    public updated(changedProperties: PropertyValues) {
         super.updated(changedProperties);
         this.derivedValue = this.observableValue * 3;
     }
@@ -95,9 +101,7 @@ export class TestMobxLitElementFirstUpdatedChange extends MobxLitElement {
     @observable
     private derivedValue: number = 1;
 
-    public firstUpdated(
-        changedProperties: Map<string | number | symbol, unknown>
-    ) {
+    public firstUpdated(changedProperties: PropertyValues) {
         super.firstUpdated(changedProperties);
         this.derivedValue = this.observableValue * 4;
     }

--- a/test/test-elements.ts
+++ b/test/test-elements.ts
@@ -1,0 +1,102 @@
+import {
+    customElement,
+    PropertyValues,
+    TemplateResult,
+    html,
+    property,
+} from 'lit-element';
+import { observable, computed } from 'mobx';
+import { MobxLitElement } from '../lit-mobx';
+import { nothing } from 'lit-html';
+
+@customElement('test-mobx-lit-element-updates-arrays')
+export class TestMobxLitElementUpdatesArrays extends MobxLitElement {
+    @property({ attribute: false })
+    @observable
+    public observableArray?: string[];
+
+    @property()
+    public normalProperty = 'My Array';
+
+    @computed
+    private get arrayLength(): string {
+        return `Array length = ${
+            this.observableArray ? this.observableArray.length : 'N/A'
+        }`;
+    }
+
+    public render(): TemplateResult {
+        return html`
+            <p>${this.normalProperty}</p>
+            <p>
+                ${this.observableArray
+                    ? this.observableArray.join(', ')
+                    : nothing}
+            </p>
+            <p>${this.arrayLength}</p>
+        `;
+    }
+}
+
+@customElement('test-mobx-lit-element-update-change')
+export class TestMobxLitElementUpdateChange extends MobxLitElement {
+    @observable
+    public observableValue: number = 1;
+
+    @observable
+    private derivedValue: number = 1;
+
+    public update(changedProperties: PropertyValues) {
+        super.update(changedProperties);
+        this.derivedValue = this.observableValue * 2;
+    }
+
+    public render(): TemplateResult {
+        return html`
+            <p>${this.observableValue}</p>
+            <p>${this.derivedValue}</p>
+        `;
+    }
+}
+
+@customElement('test-mobx-lit-element-updated-change')
+export class TestMobxLitElementUpdatedChange extends MobxLitElement {
+    @observable
+    public observableValue: number = 1;
+
+    @observable
+    private derivedValue: number = 1;
+
+    public updated(changedProperties: PropertyValues) {
+        super.updated(changedProperties);
+        this.derivedValue = this.observableValue * 3;
+    }
+
+    public render(): TemplateResult {
+        return html`
+            <p>${this.observableValue}</p>
+            <p>${this.derivedValue}</p>
+        `;
+    }
+}
+
+@customElement('test-mobx-lit-element-first-updated-change')
+export class TestMobxLitElementFirstUpdatedChange extends MobxLitElement {
+    @observable
+    public observableValue: number = 1;
+
+    @observable
+    private derivedValue: number = 1;
+
+    public firstUpdated(changedProperties: PropertyValues) {
+        super.firstUpdated(changedProperties);
+        this.derivedValue = this.observableValue * 4;
+    }
+
+    public render(): TemplateResult {
+        return html`
+            <p>${this.observableValue}</p>
+            <p>${this.derivedValue}</p>
+        `;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Issue #26 tracks a problem where changes made during `firstUpdated` were not being properly reacted to, this was due to the Reaction only being setup after `firstUpdated` was called and thus not detecting changes made during `firstUpdated`.

This change switches to creating Reaction around `update` instead, then when `firstUpdated` is called changes are observed and a new update is requested.

## Related Issue

#26 

## Motivation and Context

We should honor the semantics of `lit-element` and update in the same manner.

## How Has This Been Tested?

Updated unit tests to cover this case.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
