### PR TITLE
chore: add dependbot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+    - package-ecosystem: 'npm'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+          day: 'tuesday'
+          time: '12:00'
+          timezone: 'America/Los_Angeles'
+      open-pull-requests-limit: 5
+      reviewers:
+          - 'benjamind'
+          - 'westbrook'


### PR DESCRIPTION
## Description 
With the end of Greenkeeper, dependbot is a GitHub native bot for maintaining dependency versions.

Questions that might matter:
- What day of the week it does a review?
- How many packages can it submit PRs for at a time?
- Whether anyone else should be on the PRs it creates.