### PR TITLE
fix: mobx6 removed IDerivation type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/lit-mobx",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "description": "Integrating mobx with lit-element!",
     "license": "Apache-2.0",
     "repository": "https://github.com/adobe/lit-mobx",

--- a/src/lib/mixin-custom.ts
+++ b/src/lib/mixin-custom.ts
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import { ReactiveElement, PropertyValues } from 'lit';
-import type { IDerivation, Reaction } from 'mobx';
+import type { Reaction } from 'mobx';
 
 const reaction = Symbol('LitMobxRenderReaction');
 const cachedRequestUpdate = Symbol('LitMobxRequestUpdate');
@@ -21,14 +21,7 @@ export type ReactiveElementConstructor = new (
 ) => ReactiveElement;
 
 export interface ReactionConstructor {
-    new (
-        name: string,
-        onInvalidate: () => void,
-        errorHandler?:
-            | ((error: any, derivation: IDerivation) => void)
-            | undefined,
-        requiresObservable?: boolean
-    ): Reaction;
+    new (...args: any[]): Reaction;
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Relaxes types on the ReactionConstructor to allow working with latest mobx6 which removed the IDerivation type from public interface.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
